### PR TITLE
Hotfix/broken tests

### DIFF
--- a/client/middleware_test.go
+++ b/client/middleware_test.go
@@ -25,9 +25,9 @@ func TestFunc(t *testing.T) {
 
 	//nolint:bodyclose
 	actual, actualErr := Func(func(r *http.Request) (*http.Response, error) {
-		assert.True(request == r)
+		assert.Same(request, r)
 		return expected, expectedErr
-	})(request)
+	}).Do(request)
 
 	assert.True(expected == actual)
 	assert.Equal(expectedErr, actualErr)

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,12 @@
 module github.com/xmidt-org/httpaux
 
-go 1.14
+go 1.20
 
 require github.com/stretchr/testify v1.8.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/roundtrip/middleware_test.go
+++ b/roundtrip/middleware_test.go
@@ -26,7 +26,7 @@ func TestFunc(t *testing.T) {
 	actual, actualErr := Func(func(r *http.Request) (*http.Response, error) {
 		assert.True(request == r)
 		return expected, expectedErr
-	})(request)
+	}).RoundTrip(request)
 
 	assert.True(expected == actual)
 	assert.Equal(expectedErr, actualErr)


### PR DESCRIPTION
Fixed the issue with the broken unit tests.  `golang` 1.20 is stricter and more correct, and it caught (2) bad unit tests.